### PR TITLE
update Illuminance at least every 60 seconds, even if value not changed

### DIFF
--- a/2a/yaml/beta/human-sensor-2a-beta-github.yaml
+++ b/2a/yaml/beta/human-sensor-2a-beta-github.yaml
@@ -60,6 +60,10 @@ globals:
     type: float
     restore_value: no
     initial_value: "-1"
+  - id: last_illuminance_timestamp
+    type: int
+    restore_value: no
+    initial_value: "-1"
 
 improv_serial:
   
@@ -686,17 +690,25 @@ sensor:
     update_interval: 1s
     filters:
       - lambda: !lambda |-
+          auto time = id(time_now).utcnow().timestamp;
           if (id(last_illuminance) == x){
-            return {};
+            if (time >= (id(last_illuminance_timestamp) + 60)){
+              id(last_illuminance_timestamp) = time;
+              return x;
+            } else {
+              return {};
+            }
           }
           if (id(bh1750_fast_update).state){
             id(last_illuminance) = x;
             // ESP_LOGD("custom", "Fast Update BH1850");
+            id(last_illuminance_timestamp) = time;
             return x;
           }
           if (abs(id(last_illuminance) - x) > 1){
 
               id(last_illuminance) = x;
+              id(last_illuminance_timestamp) = time;
               return x;
           }
           return {};

--- a/2a/yaml/beta/human-sensor-2a-beta-github.yaml
+++ b/2a/yaml/beta/human-sensor-2a-beta-github.yaml
@@ -688,6 +688,7 @@ sensor:
     accuracy_decimals: 1
     id: bh1750_light
     update_interval: 1s
+    force_update: true
     filters:
       - lambda: !lambda |-
           auto time = id(time_now).utcnow().timestamp;


### PR DESCRIPTION
i want to use a statistic sensor over the illuminance value to give me the minimal value of the last 15 minutes, but because the sensor don't update the value if it isn't changing, the statistic sensor runs out of samples and get unavailable.
this commit should fix it by sending a value at least every 60 seconds, even when the value doesn't changed and therefore create a sample inside home assistant every 60 seconds.